### PR TITLE
Make the BuildContext parameter optional

### DIFF
--- a/lib/src/extensions/src/string.dart
+++ b/lib/src/extensions/src/string.dart
@@ -16,7 +16,7 @@ extension LocalizedStringExt on String {
   ///   - context: The `BuildContext` used to find the `LocalizationProvider` and `LocalizationManager`.
   ///
   /// - Returns: The translated string, or the default not found text if the key is not found.
-  String tr(BuildContext context) {
+  String tr([BuildContext? context]) {
     return LocalizationProvider.of(context).translate(this);
   }
 
@@ -32,7 +32,7 @@ extension LocalizedStringExt on String {
   ///   - params: A map of parameters to replace placeholders in the translation string.
   ///
   /// - Returns: The translated string with parameters, or the default not found text if the key is not found.
-  String trParams(BuildContext context, Map<String, dynamic> params) {
+  String trParams(Map<String, dynamic> params, [BuildContext? context]) {
     return LocalizationProvider.of(context).translateWithParams(this, params);
   }
 }

--- a/lib/src/extensions/src/text.dart
+++ b/lib/src/extensions/src/text.dart
@@ -32,8 +32,7 @@ extension LocalizedTextExt on Text {
   ///   A Text widget displaying the localized string.
   Text tr(BuildContext context) {
     return Text(
-      data!.tr(
-          context), // `data` is assumed to be a String (the text content of this widget).
+      data!.tr(context), // `data` is assumed to be a String (the text content of this widget).
       style: style,
       textAlign: textAlign,
       overflow: overflow,
@@ -58,9 +57,9 @@ extension LocalizedTextExt on Text {
   ///
   /// Returns:
   ///   A Text widget displaying the localized string with parameters.
-  Text trParams(BuildContext context, {required Map<String, dynamic> params}) {
+  Text trParams({required Map<String, dynamic> params, BuildContext? context}) {
     return Text(
-      data!.trParams(context, params),
+      data!.trParams(params, context),
       style: style,
       textAlign: textAlign,
       overflow: overflow,

--- a/lib/src/provider/provider.dart
+++ b/lib/src/provider/provider.dart
@@ -7,6 +7,9 @@ import 'package:localization_pro/src/manager/localization_manager.dart';
 /// down the widget tree, allowing widgets to access localization functionalities
 /// provided by [LocalizationManager].
 class LocalizationProvider extends InheritedWidget {
+  /// The key used to access the [LocalizationProvider] instance.
+  static GlobalKey instanceKey = GlobalKey();
+
   /// The localization manager that holds and manages all localization data.
   final LocalizationManager localizationManager;
 
@@ -18,8 +21,7 @@ class LocalizationProvider extends InheritedWidget {
   /// [localizationManager].
   /// [localizationManager] The single instance of [LocalizationManager] to be provided
   /// to all dependent widgets.
-  const LocalizationProvider(
-      {super.key, required super.child, required this.localizationManager});
+  LocalizationProvider({Key? key, required super.child, required this.localizationManager}) : super(key: key ?? instanceKey);
 
   /// Determines whether the framework should notify widgets that inherit from this widget.
   ///
@@ -37,12 +39,21 @@ class LocalizationProvider extends InheritedWidget {
   /// properly configured provider.
   ///
   /// [context] The build context which will be used to look up the [LocalizationProvider].
-  static LocalizationManager of(BuildContext context) {
-    final LocalizationProvider? result =
-        context.dependOnInheritedWidgetOfExactType<LocalizationProvider>();
+  static LocalizationManager of(BuildContext? context) {
+    final LocalizationProvider? result;
+
+    if (context != null) {
+      result = context.dependOnInheritedWidgetOfExactType<LocalizationProvider>();
+    } else {
+      {
+        result = instanceKey.currentContext?.dependOnInheritedWidgetOfExactType<LocalizationProvider>();
+      }
+    }
+
     if (result == null) {
       throw FlutterError('LocalizationProvider not found in context');
     }
+
     return result.localizationManager;
   }
 }


### PR DESCRIPTION
I have added an instanceKey field to LocalizationProvider. If the context is null, we use this key to get instance of LocalizationProvider. The context parameters of extensions are now optional.

I lightly tested it, and this approach is working. 
I'm creating this pull request just to give an idea. 

